### PR TITLE
Made some functions extern so they can be used by other plugins natively

### DIFF
--- a/src/Managers/ArousalManager.cpp
+++ b/src/Managers/ArousalManager.cpp
@@ -8,72 +8,108 @@ using namespace PersistedData;
 
 namespace ArousalManager
 {
-	float GetArousal(RE::Actor* actorRef, bool bUpdateState)
-	{
-		if (!actorRef) {
-			return -2.f;
-		}
+    float GetArousal(RE::Actor* actorRef, bool bUpdateState)
+    {
+        if (!actorRef) {
+            return -2.f;
+        }
 
-		RE::FormID actorFormId = actorRef->formID;
+        RE::FormID actorFormId = actorRef->formID;
 
-		const auto LastCheckTimeData = LastCheckTimeData::GetSingleton();
-		auto lastCheckTime = LastCheckTimeData->GetData(actorFormId, 0.f);
-		float curTime = RE::Calendar::GetSingleton()->GetCurrentGameTime();
-		float gameHoursPassed = (curTime - lastCheckTime) * 24;
+        const auto LastCheckTimeData = LastCheckTimeData::GetSingleton();
+        auto lastCheckTime = LastCheckTimeData->GetData(actorFormId, 0.f);
+        float curTime = RE::Calendar::GetSingleton()->GetCurrentGameTime();
+        float gameHoursPassed = (curTime - lastCheckTime) * 24;
 
-		float newArousal = CalculateArousal(actorRef, gameHoursPassed);
+        float newArousal = CalculateArousal(actorRef, gameHoursPassed);
 
-		//If set to update state, or we have never checked (last check time is 0), then update the lastchecktime
-		if (bUpdateState || lastCheckTime == 0.f) {
-			LastCheckTimeData->SetData(actorFormId, curTime);
-			SetArousal(actorRef, newArousal);
+        //If set to update state, or we have never checked (last check time is 0), then update the lastchecktime
+        if (bUpdateState || lastCheckTime == 0.f) {
+            LastCheckTimeData->SetData(actorFormId, curTime);
+            SetArousal(actorRef, newArousal);
 
-			LibidoManager::GetSingleton()->UpdateActorLibido(actorRef, gameHoursPassed, newArousal);
-		}
-		//logger::debug("Got Arousal for {} val: {}", actorRef->GetDisplayFullName(), newArousal);
-		return newArousal;
-	}
+            LibidoManager::GetSingleton()->UpdateActorLibido(actorRef, gameHoursPassed, newArousal);
+        }
+        //logger::debug("Got Arousal for {} val: {}", actorRef->GetDisplayFullName(), newArousal);
+        return newArousal;
+    }
 
-	float SetArousal(RE::Actor* actorRef, float value)
-	{
-		value = std::clamp(value, 0.0f, 100.f);
+    float SetArousal(RE::Actor* actorRef, float value)
+    {
+        value = std::clamp(value, 0.0f, 100.f);
 
-		ArousalData::GetSingleton()->SetData(actorRef->formID, value);
+        ArousalData::GetSingleton()->SetData(actorRef->formID, value);
 
-		Papyrus::Events::SendActorArousalUpdatedEvent(actorRef, value);
+        Papyrus::Events::SendActorArousalUpdatedEvent(actorRef, value);
 
-		return value;
-	}
+        return value;
+    }
 
-	float ModifyArousal(RE::Actor* actorRef, float modValue)
-	{
-		modValue *= PersistedData::ArousalMultiplierData::GetSingleton()->GetData(actorRef->formID, 1.f);
+    float ModifyArousal(RE::Actor* actorRef, float modValue)
+    {
+        modValue *= PersistedData::ArousalMultiplierData::GetSingleton()->GetData(actorRef->formID, 1.f);
 
-		float currentArousal = GetArousal(actorRef, false);
-		return SetArousal(actorRef, currentArousal + modValue);
-	}
+        float currentArousal = GetArousal(actorRef, false);
+        return SetArousal(actorRef, currentArousal + modValue);
+    }
 
-	float CalculateArousal(RE::Actor* actorRef, float gameHoursPassed)
-	{
-		float currentArousal = ArousalData::GetSingleton()->GetData(actorRef->formID, -2.f);
-		
-		//If never calculated, regen
-		if (currentArousal < -1) {
-			currentArousal = Utilities::GenerateRandomFloat(10.f, 50.f);
-			//logger::debug("Random Arousal: {} Val: {}", actorRef->GetDisplayFullName(), currentArousal);
-			return currentArousal;
-		}
+    float CalculateArousal(RE::Actor* actorRef, float gameHoursPassed)
+    {
+        float currentArousal = ArousalData::GetSingleton()->GetData(actorRef->formID, -2.f);
+        
+        //If never calculated, regen
+        if (currentArousal < -1) {
+            currentArousal = Utilities::GenerateRandomFloat(10.f, 50.f);
+            //logger::debug("Random Arousal: {} Val: {}", actorRef->GetDisplayFullName(), currentArousal);
+            return currentArousal;
+        }
 
-		float currentArousalBaseline = LibidoManager::GetSingleton()->GetBaselineArousal(actorRef);
+        float currentArousalBaseline = LibidoManager::GetSingleton()->GetBaselineArousal(actorRef);
 
-		float epsilon = Settings::GetSingleton()->GetArousalChangeRate();
-		//logger::trace("CalculateArousal: epsilon: {}", epsilon);
+        float epsilon = Settings::GetSingleton()->GetArousalChangeRate();
+        //logger::trace("CalculateArousal: epsilon: {}", epsilon);
 
 
-		float t = 1.f - std::pow(epsilon, gameHoursPassed);
-		float newArousal = std::lerp(currentArousal, currentArousalBaseline, t);
-		//logger::trace("CalculateArousal: {} from: {} newArousal {} Diff: {}  t: {}", actorRef->GetDisplayFullName(), currentArousal, newArousal, newArousal - currentArousal, t);
+        float t = 1.f - std::pow(epsilon, gameHoursPassed);
+        float newArousal = std::lerp(currentArousal, currentArousalBaseline, t);
+        //logger::trace("CalculateArousal: {} from: {} newArousal {} Diff: {}  t: {}", actorRef->GetDisplayFullName(), currentArousal, newArousal, newArousal - currentArousal, t);
 
-		return newArousal;
-	}
+        return newArousal;
+    }
+
+    float GetArousalExt(RE::Actor* actorRef)
+    {
+        if (!actorRef) {
+            return -2.f;
+        }
+        float newArousal = CalculateArousal(actorRef, 0.0f);
+        return newArousal;
+    }
+
+    float SetArousalExt(RE::Actor* actorRef, float value, bool sendevent)
+    {
+        value = std::clamp(value, 0.0f, 100.f);
+        ArousalData::GetSingleton()->SetData(actorRef->formID, value);
+        
+        //send event
+        if (sendevent)
+        {
+            auto loc_handle = actorRef->GetHandle().native_handle();
+            SKSE::GetTaskInterface()->AddTask([loc_handle,value]
+            {
+                 Papyrus::Events::SendActorArousalUpdatedEvent(RE::Actor::LookupByHandle(loc_handle).get(), value);
+            });
+        }
+
+        
+        return value;
+    }
+
+    float ModifyArousalExt(RE::Actor* actorRef, float modValue, bool sendevent)
+    {
+        modValue *= PersistedData::ArousalMultiplierData::GetSingleton()->GetData(actorRef->formID, 1.f);
+        float currentArousal = GetArousalExt(actorRef);
+        auto loc_res = SetArousalExt(actorRef, currentArousal + modValue,sendevent);
+        return loc_res;
+    }
 }

--- a/src/Managers/ArousalManager.h
+++ b/src/Managers/ArousalManager.h
@@ -9,4 +9,9 @@ namespace ArousalManager
 	float ModifyArousal(RE::Actor* actorRef, float value);
 
 	float CalculateArousal(RE::Actor* actorRef, float timePassed);
+
+	//modified functions to allow paralel proc from different plugin
+	extern "C" DLLEXPORT float GetArousalExt(RE::Actor* actorRef);
+	extern "C" DLLEXPORT float SetArousalExt(RE::Actor* actorRef, float value, bool sendevent);
+	extern "C" DLLEXPORT float ModifyArousalExt(RE::Actor* actorRef, float value,bool sendevent);
 }


### PR DESCRIPTION
As title said, this only copies some important arousal related functions and made them extern, so they can be called from other mods natively. 

Main reason why I did it is that my mod Unforgiving Device needs accurate arousal calculation, which is updated on every frame (it is part of new orgasm system). For that reason, the papyrus event is not called by extern function. Instead modder have to decide when to call event so it doesnt clogg the engine. 

I'm using this edit for long time and didn't found any issues yet. It was also tested by other users and they didn't encounter any issues either.

It is imported here: https://github.com/IHateMyKite/UnforgivingDevicesNative/blob/b2cac504c7e3a894a15e615a1aee934a157cc84a/src/OrgasmSystem/OrgasmManager.cpp#L16-L27

And used here: https://github.com/IHateMyKite/UnforgivingDevicesNative/blob/b2cac504c7e3a894a15e615a1aee934a157cc84a/src/OrgasmSystem/OrgasmData.cpp#L57