### PR TITLE
Fix Papyrus deployment and improve documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/src/PersistedData.h
+++ b/src/PersistedData.h
@@ -317,9 +317,10 @@ namespace PersistedData
 	void LoadCallback(SKSE::SerializationInterface* serializationInterface);
 	void RevertCallback(SKSE::SerializationInterface* serializationInterface);
 
-	// Post-load self-healing: clamps/repairs persisted per-actor values that could otherwise leave arousal permanently stuck
-	// (e.g. a multiplier of 0 that freezes all arousal gains, or out-of-range/non-finite values from a corrupted or externally edited save).
-	// Safe to call after LoadCallback.
+	// Post-load self-healing: clamps/repairs persisted per-actor values that could otherwise corrupt
+	// the arousal system (out-of-range, negative, or non-finite values from a corrupted or externally
+	// edited save). Legitimate-but-extreme in-range values are preserved (e.g. a multiplier of 0, which
+	// is a valid "no arousal gains" setting). Safe to call after LoadCallback.
 	void SanitizeLoadedData();
 
 	void ResetSystemForModeSwitch();

--- a/src/RuntimeEvents.cpp
+++ b/src/RuntimeEvents.cpp
@@ -246,7 +246,7 @@ static void RunWorldArousalUpdate()
 					spectatorNudityScores[spectator] = std::max(it->second, nudityScore);
 				}
 
-				// HandleSpectatingNaked already scales gains based on AND score internally (SLA mode only)
+				// HandleSpectatingNaked scales gains by AND nudity score internally (both OSL and SLA modes)
 				ArousalManager::GetSingleton()->GetArousalSystem().HandleSpectatingNaked(spectator, actor, elapsedGameTimeSinceLastCheck);
 			}
 		}

--- a/xmake.lua
+++ b/xmake.lua
@@ -60,9 +60,15 @@ rule("oslaroused.deploy", function()
                 --  Devious Devices patch is FOMOD-optional, so neither is auto-deployed.)
                 os.cp(path.join(contrib, "Assets", "*"), dir)
                 os.cp(path.join(contrib, "Config", "*.ini"), plugindir)
-                local scriptdir = path.join(dir, "Scripts")
-                os.mkdir(scriptdir)
-                os.cp(path.join(contrib, "PapyrusRelease", "*.pex"), scriptdir)
+
+                -- PapyrusRelease is produced by a separate Papyrus compile step, so it may
+                -- not exist yet on a DLL-only build; only deploy scripts when present.
+                local papyrusdir = path.join(contrib, "PapyrusRelease")
+                if os.isdir(papyrusdir) then
+                    local scriptdir = path.join(dir, "Scripts")
+                    os.mkdir(scriptdir)
+                    os.cp(path.join(papyrusdir, "*.pex"), scriptdir)
+                end
             end
         end
     end)


### PR DESCRIPTION
## Summary
This PR addresses a build robustness issue and clarifies documentation around arousal system behavior and data sanitization.

## Key Changes

- **Build System**: Made Papyrus script deployment conditional in `xmake.lua`
  - The `PapyrusRelease` directory may not exist on DLL-only builds (when Papyrus compilation is skipped)
  - Added a directory existence check before attempting to copy `.pex` files
  - Prevents build failures when scripts haven't been compiled separately

- **Documentation**: Improved clarity in code comments
  - Updated `PersistedData.h` comment for `SanitizeLoadedData()` to clarify that the function preserves legitimate-but-extreme values (e.g., a multiplier of 0 is a valid "no arousal gains" setting) while only repairing corrupted data
  - Updated `RuntimeEvents.cpp` comment to clarify that `HandleSpectatingNaked` scales gains by AND nudity score in both OSL and SLA modes (not just SLA)

- **Dependency**: Removed `lib/commonlibsse` submodule reference (transitive artifact)

## Implementation Details

The Papyrus deployment fix wraps the script copy operation in an `os.isdir()` check, allowing builds to succeed whether or not the Papyrus compiler has been run. This is particularly useful for CI/CD pipelines or development workflows where DLL and script compilation may be decoupled.