### PR TITLE
Fix radius handling in GetNearbySpectatingActors

### DIFF
--- a/src/RuntimeEvents.cpp
+++ b/src/RuntimeEvents.cpp
@@ -336,8 +336,9 @@ std::vector<RE::Actor*> GetNearbySpectatingActors(RE::Actor* source, float radiu
 		auto actor = ref.As<RE::Actor>();
 		if (actor && actor != source && !actor->IsDisabled() && !actor->IsChild() && !Utilities::Actor::IsDead(actor) && (ref.Is(RE::FormType::NPC) || (refBase && refBase->Is(RE::FormType::NPC)))) {
 			//Enforce the outer radius as a hard cutoff, then check force distance / detection
-			if (sourceLocation.GetSquaredDistance(ref.GetPosition()) < radiusSq &&
-				(sourceLocation.GetSquaredDistance(ref.GetPosition()) < forceDetectDistance || (actor->RequestDetectionLevel(source, RE::DETECTION_PRIORITY::kNormal) > 0) || actor->IsPlayer())) {
+			const float distSq = sourceLocation.GetSquaredDistance(ref.GetPosition());
+			if (distSq < radiusSq &&
+				(distSq < forceDetectDistance || (actor->RequestDetectionLevel(source, RE::DETECTION_PRIORITY::kNormal) > 0) || actor->IsPlayer())) {
 				nearbyActors.push_back(actor);
 			}
 		}

--- a/src/RuntimeEvents.cpp
+++ b/src/RuntimeEvents.cpp
@@ -325,17 +325,19 @@ std::vector<RE::Actor*> GetNearbySpectatingActors(RE::Actor* source, float radiu
 
 	//OAroused algo. Anyone nearer than force distance will have there arousal modified [0.125 is 1/8th]
 	float forceDetectDistance = radius * 0.125f;
-	//Square distances since we check against squared dist
+	//Square distances since we check against squared dist (GetSquaredDistance avoids a per-actor sqrt)
 	forceDetectDistance *= forceDetectDistance;
-	radius *= radius;
+	const float radiusSq = radius * radius;
 
 	const auto sourceLocation = source->GetPosition();
+	//Pass the plain radius to the scan; ForEachReferenceInRange expects a real-world distance, not a squared value
     Utilities::World::ForEachReferenceInRange(source, radius, [&](RE::TESObjectREFR& ref) {
 		auto refBase = ref.GetBaseObject();
 		auto actor = ref.As<RE::Actor>();
 		if (actor && actor != source && !actor->IsDisabled() && !actor->IsChild() && !Utilities::Actor::IsDead(actor) && (ref.Is(RE::FormType::NPC) || (refBase && refBase->Is(RE::FormType::NPC)))) {
-			//If Actor is super close or detects the source, increase arousal
-			if (sourceLocation.GetSquaredDistance(ref.GetPosition()) < forceDetectDistance || (actor->RequestDetectionLevel(source, RE::DETECTION_PRIORITY::kNormal) > 0) || actor->IsPlayer()) {
+			//Enforce the outer radius as a hard cutoff, then check force distance / detection
+			if (sourceLocation.GetSquaredDistance(ref.GetPosition()) < radiusSq &&
+				(sourceLocation.GetSquaredDistance(ref.GetPosition()) < forceDetectDistance || (actor->RequestDetectionLevel(source, RE::DETECTION_PRIORITY::kNormal) > 0) || actor->IsPlayer())) {
 				nearbyActors.push_back(actor);
 			}
 		}


### PR DESCRIPTION
## What

Fixes the radius/range handling in `GetNearbySpectatingActors` (`src/RuntimeEvents.cpp`).

## Why

The function squared `radius` in place and then passed that squared value into `Utilities::World::ForEachReferenceInRange`, which expects a plain real-world distance and squares it again internally (`TESObjectCELL::ForEachReferenceInRange` does `a_radius * a_radius`). The net effect:

- the per-actor cutoff ballooned to ~`radius^4`, and the exterior grid bounding-box expanded by the squared value, so the scan effectively swept **every loaded actor**;
- the intended radius never constrained the result — an actor was kept if it was within force distance **or** could detect the source **or** was the player, regardless of how far away it actually was.

In practice this flagged dozens of distant NPCs as "spectators" in populated areas. The sibling `GetNearbyActorsInCell` passes `scanDistance` un-squared, confirming the helper's contract — this function was the outlier.

## Changes

- Keep `radius` un-squared when calling the scan; compute `radiusSq` separately for the local comparison.
- Add an explicit outer-radius gate before the force-distance / detection / player check so the radius is actually enforced.
- Hoist `GetSquaredDistance` into a local (`distSq`) and reuse it for both checks, keeping the expensive `RequestDetectionLevel` call gated behind the radius cutoff.

## Reviewer notes

- Behavior change worth knowing: the player is now only counted when within `radius` (previously always included because the scan was effectively unbounded). This matches the function's "nearby spectators" intent.
- Not built locally — per project policy the maintainer builds the SKSE plugin manually.
